### PR TITLE
feat: add AdaptiveSummary plot and rename SummaryPlot to ThresholdSummary

### DIFF
--- a/pythermalcomfort/plots/matplotlib/__init__.py
+++ b/pythermalcomfort/plots/matplotlib/__init__.py
@@ -3,20 +3,25 @@ from pythermalcomfort.plots.matplotlib.adaptive import (
     AdaptivePlotResult,
     RegionsConfig,
 )
+from pythermalcomfort.plots.matplotlib.adaptive_summary import AdaptiveSummary
 from pythermalcomfort.plots.matplotlib.psychrometric import PsychrometricPlot
-from pythermalcomfort.plots.matplotlib.summary import SummaryPlot, SummaryPlotResult
 from pythermalcomfort.plots.matplotlib.threshold import (
     ThresholdPlot,
     ThresholdPlotResult,
+)
+from pythermalcomfort.plots.matplotlib.threshold_summary import (
+    SummaryPlotResult,
+    ThresholdSummary,
 )
 
 __all__ = [
     "ThresholdPlot",
     "ThresholdPlotResult",
-    "SummaryPlot",
+    "ThresholdSummary",
     "SummaryPlotResult",
     "PsychrometricPlot",
     "AdaptivePlot",
     "AdaptivePlotResult",
+    "AdaptiveSummary",
     "RegionsConfig",
 ]

--- a/pythermalcomfort/plots/matplotlib/adaptive_summary.py
+++ b/pythermalcomfort/plots/matplotlib/adaptive_summary.py
@@ -1,0 +1,449 @@
+"""Class-based summary plotting for adaptive comfort regions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+from matplotlib.legend import Legend
+from matplotlib.patches import Patch
+
+from pythermalcomfort.models.adaptive_ashrae import adaptive_ashrae
+from pythermalcomfort.models.adaptive_en import adaptive_en
+from pythermalcomfort.plots.matplotlib._base import BasePlot
+from pythermalcomfort.plots.matplotlib._shared import (
+    _PYTHERMALCOMFORT_RC,
+    _PlotDefaults,
+    _resolve_region_colors,
+)
+from pythermalcomfort.plots.matplotlib.threshold_summary import (
+    SummaryPlotResult,
+    _apply_compact_layout,
+    _default_legend_ncol,
+    _ensure_title_legend_spacing,
+    _plot_summary,
+    _prepare_axis,
+    _should_show_region_labels,
+    _summary_figsize,
+    _validate_dataframe,
+)
+
+# ── standard configuration ─────────────────────────────────────────────────
+
+_ADAPTIVE_STANDARDS: dict[str, dict[str, Any]] = {
+    "acceptability": {
+        "model_func": adaptive_ashrae,
+        # ordered widest → narrowest (90 % band ⊂ 80 % band)
+        "band_order": [80, 90],
+        "default_labels": {
+            80: "80% Acceptability",
+            90: "90% Acceptability",
+        },
+    },
+    "acceptability_cat": {
+        "model_func": adaptive_en,
+        # ordered widest → narrowest (Cat I ⊂ Cat II ⊂ Cat III)
+        "band_order": ["iii", "ii", "i"],
+        "default_labels": {
+            "iii": "Category III",
+            "ii": "Category II",
+            "i": "Category I",
+        },
+    },
+}
+
+_REQUIRED_INPUT_COLUMNS: list[str] = ["tdb", "tr", "t_running_mean", "v"]
+
+# ── internal resolved container ────────────────────────────────────────────
+
+
+@dataclass
+class _AdaptiveRegionConfig:
+    """Fully-resolved adaptive region configuration (internal use only)."""
+
+    output_prefix: str
+    standard_key: str
+    band_keys: list  # sorted widest → narrowest
+    labels: list[str]  # length = len(band_keys) + 1
+    colors: list[str]  # length = len(band_keys) + 1
+
+
+# ── public API ─────────────────────────────────────────────────────────────
+
+
+class AdaptiveSummary(BasePlot):
+    """Build and render an adaptive comfort summary from input measurements.
+
+    Runs the appropriate adaptive comfort model (ASHRAE 55 or EN 16798) on
+    every row of the input DataFrame, assigns each row to the narrowest
+    comfort band it satisfies, and displays the result as a stacked bar
+    chart identical in style to :class:`ThresholdSummary`.
+
+    The DataFrame must contain columns ``tdb``, ``tr``,
+    ``t_running_mean``, and ``v``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pythermalcomfort.plots.matplotlib import AdaptiveSummary
+
+        # ASHRAE 55
+        result = (
+            AdaptiveSummary(df)
+            .set_regions(output="acceptability", thresholds=[80, 90])
+            .plot(title="Adaptive Comfort Summary (ASHRAE 55)")
+        )
+
+        # EN 16798
+        result = (
+            AdaptiveSummary(df)
+            .set_regions(
+                output="acceptability_cat",
+                thresholds=["i", "ii", "iii"],
+            )
+            .plot(title="Adaptive Comfort Summary (EN 16798)")
+        )
+    """
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        """Initialize an adaptive summary builder from a DataFrame.
+
+        Parameters
+        ----------
+        df : DataFrame
+            Input DataFrame containing measurement columns (``tdb``, ``tr``,
+            ``t_running_mean``, ``v``).
+
+        Raises
+        ------
+        TypeError
+            If *df* is not a pandas DataFrame.
+        ValueError
+            If *df* is empty.
+        """
+        super().__init__()
+        _validate_dataframe(df)
+        self._df = df
+        self._adaptive_config: _AdaptiveRegionConfig | None = None
+        self._model_params: dict[str, Any] = {}
+
+    # ── configuration ──────────────────────────────────────────────────────
+
+    def set_regions(
+        self,
+        *,
+        output: str,
+        thresholds: Sequence,
+        labels: Sequence[str] | None = None,
+        colors: Sequence[str] | None = None,
+    ) -> AdaptiveSummary:
+        """Configure which adaptive comfort bands to display.
+
+        Parameters
+        ----------
+        output : str
+            Selects the adaptive model via naming convention:
+
+            - ``"acceptability"`` → ASHRAE 55
+              (valid thresholds: ``80``, ``90``)
+            - ``"acceptability_cat"`` → EN 16798
+              (valid thresholds: ``"i"``, ``"ii"``, ``"iii"``)
+
+        thresholds : sequence
+            Band keys to display.  Order does not matter — bands are always
+            arranged from widest to narrowest internally.  The resulting
+            number of regions is ``len(thresholds) + 1`` (one extra region
+            for data points outside all selected bands).
+        labels : sequence of str, optional
+            Custom region labels.  Must have length ``len(thresholds) + 1``.
+        colors : sequence of str, optional
+            Custom region colors.  Same length rule as *labels*.
+
+        Returns
+        -------
+        AdaptiveSummary
+            Self, to support method chaining.
+
+        Raises
+        ------
+        TypeError
+            If *output* is not a string.
+        ValueError
+            If *output* is unrecognised, thresholds are invalid or empty,
+            required DataFrame columns are missing, or labels/colors have
+            the wrong length.
+        """
+        if not isinstance(output, str):
+            raise TypeError("output must be a string.")
+
+        output_name = output.strip()
+        if output_name not in _ADAPTIVE_STANDARDS:
+            valid = ", ".join(f"'{k}'" for k in sorted(_ADAPTIVE_STANDARDS))
+            msg = f"output must be one of {valid}, got '{output_name}'."
+            raise ValueError(msg)
+
+        std_cfg = _ADAPTIVE_STANDARDS[output_name]
+        band_order: list = std_cfg["band_order"]
+        valid_keys = set(band_order)
+
+        # ── validate thresholds ────────────────────────────────────────────
+        if not thresholds:
+            raise ValueError("thresholds must contain at least one band key.")
+
+        normalized: list = []
+        for t in thresholds:
+            if isinstance(band_order[0], int):
+                try:
+                    normalized.append(int(t))
+                except (TypeError, ValueError) as exc:
+                    msg = f"ASHRAE thresholds must be integers (80 or 90), got {t!r}."
+                    raise ValueError(msg) from exc
+            else:
+                normalized.append(str(t).strip().lower())
+
+        invalid = [t for t in normalized if t not in valid_keys]
+        if invalid:
+            msg = f"Invalid threshold(s): {invalid}. Valid keys: {band_order}"
+            raise ValueError(msg)
+
+        # deduplicate, then sort widest → narrowest
+        seen: set = set()
+        unique: list = []
+        for t in normalized:
+            if t not in seen:
+                seen.add(t)
+                unique.append(t)
+        band_keys = sorted(unique, key=lambda k: band_order.index(k))
+
+        # ── validate DataFrame columns ─────────────────────────────────────
+        missing = sorted(
+            col for col in _REQUIRED_INPUT_COLUMNS if col not in self._df.columns
+        )
+        if missing:
+            msg = (
+                f"DataFrame is missing required column(s): "
+                f"{', '.join(missing)}. "
+                f"Required columns: {', '.join(_REQUIRED_INPUT_COLUMNS)}."
+            )
+            raise ValueError(msg)
+
+        # ── build labels ───────────────────────────────────────────────────
+        n_regions = len(band_keys) + 1
+        if labels is not None:
+            if len(labels) != n_regions:
+                msg = f"labels must have length {n_regions} (got {len(labels)})."
+                raise ValueError(msg)
+            region_labels = [str(lbl) for lbl in labels]
+        else:
+            default_labels = std_cfg["default_labels"]
+            region_labels = ["Not Acceptable"]
+            for key in band_keys:
+                region_labels.append(default_labels[key])
+
+        # ── build colors ───────────────────────────────────────────────────
+        region_colors = _resolve_region_colors(n_regions=n_regions, colors=colors)
+
+        self._adaptive_config = _AdaptiveRegionConfig(
+            output_prefix=output_name,
+            standard_key=output_name,
+            band_keys=band_keys,
+            labels=region_labels,
+            colors=region_colors,
+        )
+        return self
+
+    def set_params(self, **kwargs: Any) -> AdaptiveSummary:
+        """Set additional parameters forwarded to the adaptive model call.
+
+        Common parameters include ``units`` (``"SI"`` or ``"IP"``) and
+        ``limit_inputs`` (bool).  Any keyword accepted by the underlying
+        model function (``adaptive_ashrae`` or ``adaptive_en``) can be
+        passed here.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments forwarded unchanged to the model function.
+
+        Returns
+        -------
+        AdaptiveSummary
+            Self, to support method chaining.
+        """
+        self._model_params.update(kwargs)
+        return self
+
+    # ── internal evaluation ────────────────────────────────────────────────
+
+    def _evaluate_and_categorize(self) -> pd.Series:
+        """Run the model and return region percentages.
+
+        Each row is assigned to the **narrowest** comfort band it satisfies.
+        Rows outside all selected bands are labelled *Not Acceptable*.
+
+        Returns
+        -------
+        Series
+            Percentage share per region, indexed by region label.
+        """
+        cfg = self._adaptive_config
+        std_cfg = _ADAPTIVE_STANDARDS[cfg.standard_key]
+        model_func = std_cfg["model_func"]
+
+        try:
+            result = model_func(
+                tdb=self._df["tdb"].values,
+                tr=self._df["tr"].values,
+                t_running_mean=self._df["t_running_mean"].values,
+                v=self._df["v"].values,
+                **self._model_params,
+            )
+        except Exception as exc:
+            msg = f"Adaptive model evaluation failed: {exc}"
+            raise ValueError(msg) from exc
+
+        n = len(self._df)
+        categories = np.zeros(n, dtype=int)
+
+        # iterate widest → narrowest; narrower bands overwrite wider ones
+        for i, key in enumerate(cfg.band_keys):
+            attr_name = f"{cfg.output_prefix}_{key}"
+            try:
+                mask = np.asarray(getattr(result, attr_name), dtype=bool)
+            except AttributeError:
+                msg = f"Model result has no attribute '{attr_name}'."
+                raise ValueError(msg) from None
+            categories[mask] = i + 1
+
+        n_regions = len(cfg.band_keys) + 1
+        counts = np.bincount(categories, minlength=n_regions)[:n_regions]
+        pcts = np.round(counts / n * 100, 1)
+        return pd.Series(pcts, index=pd.Index(cfg.labels))
+
+    # ── plotting ───────────────────────────────────────────────────────────
+
+    def plot(
+        self,
+        *,
+        ax: Axes | None = None,
+        title: str | None = None,
+        vertical: bool = False,
+        legend: bool = True,
+        bar_kws: Mapping[str, Any] | None = None,
+        legend_kws: Mapping[str, Any] | None = None,
+    ) -> SummaryPlotResult:
+        """Render an adaptive comfort summary plot.
+
+        Parameters
+        ----------
+        ax : Axes, optional
+            Existing axis to draw on.  If ``None``, a new figure/axis is
+            created with a compact default size.
+        title : str, optional
+            Optional chart title.
+        vertical : bool
+            If ``True``, render a vertical stacked bar; otherwise horizontal.
+        legend : bool
+            Whether to draw a colour-coded legend above the bar.
+        bar_kws : dict, optional
+            Keyword overrides forwarded to ``ax.bar`` / ``ax.barh``.
+        legend_kws : dict, optional
+            Keyword overrides forwarded to ``ax.legend``.
+
+        Returns
+        -------
+        SummaryPlotResult
+            Result with figure, axis, percentages, artists, and legend.
+
+        Raises
+        ------
+        ValueError
+            If regions are not configured or model evaluation fails.
+        """
+        with mpl.rc_context(_PYTHERMALCOMFORT_RC):
+            if self._adaptive_config is None:
+                raise ValueError(
+                    "Regions are not set. Call set_regions(...) before plot(...)."
+                )
+
+            cfg = self._adaptive_config
+            show_region_labels = _should_show_region_labels(
+                legend=legend,
+                region_labels=cfg.labels,
+            )
+            created_figure = ax is None
+
+            if created_figure:
+                fig, ax = plt.subplots(
+                    figsize=_summary_figsize(
+                        vertical=vertical,
+                        legend=legend,
+                        show_region_labels=show_region_labels,
+                    )
+                )
+            else:
+                fig = ax.figure
+
+            percentages = self._evaluate_and_categorize()
+
+            _prepare_axis(ax)
+            artists = _plot_summary(
+                ax,
+                vertical=vertical,
+                region_percentages=percentages,
+                region_labels=cfg.labels,
+                region_colors=cfg.colors,
+                show_region_labels=show_region_labels,
+                bar_kws=bar_kws or {},
+            )
+
+            legend_artist: Legend | None = None
+            if legend:
+                lg_opts = dict(legend_kws or {})
+                lg_opts.setdefault("loc", "lower center")
+                lg_opts.setdefault(
+                    "bbox_to_anchor",
+                    _PlotDefaults.legend_bbox_to_anchor_with_title
+                    if title is not None
+                    else _PlotDefaults.Threshold.legend_bbox_to_anchor,
+                )
+                lg_opts.setdefault(
+                    "ncol",
+                    _default_legend_ncol(vertical=vertical, n_labels=len(cfg.labels)),
+                )
+                handles = [
+                    Patch(facecolor=color, label=label)
+                    for label, color in zip(cfg.labels, cfg.colors, strict=False)
+                ]
+                legend_artist = ax.legend(handles=handles, **lg_opts)
+
+            if title is not None:
+                ax.set_title(
+                    title,
+                    y=_PlotDefaults.title_y_with_legend if legend else None,
+                )
+
+            if created_figure:
+                _apply_compact_layout(fig)
+
+            _ensure_title_legend_spacing(
+                fig,
+                ax,
+                legend_artist,
+                adjust_layout=created_figure,
+            )
+
+            return SummaryPlotResult(
+                fig=fig,
+                ax=ax,
+                percentages=percentages,
+                artists=artists,
+                legend=legend_artist,
+            )

--- a/pythermalcomfort/plots/matplotlib/threshold_summary.py
+++ b/pythermalcomfort/plots/matplotlib/threshold_summary.py
@@ -331,7 +331,7 @@ def _default_legend_ncol(*, vertical: bool, n_labels: int) -> int:
 # ── public API ─────────────────────────────────────────────────────────────
 
 
-class SummaryPlot(BasePlot):
+class ThresholdSummary(BasePlot):
     """Build and render a threshold summary plot from tabular model outputs.
 
     The class works with an existing DataFrame that already contains the target
@@ -364,7 +364,7 @@ class SummaryPlot(BasePlot):
         thresholds: Sequence[float],
         labels: Sequence[str] | None = None,
         colors: Sequence[str] | None = None,
-    ) -> SummaryPlot:
+    ) -> ThresholdSummary:
         """Set output variable and threshold region configuration.
 
         Parameters
@@ -382,7 +382,7 @@ class SummaryPlot(BasePlot):
 
         Returns
         -------
-        SummaryPlot
+        ThresholdSummary
             Self, to support method chaining.
 
         Raises

--- a/tests/test_plot_adaptive_summary.py
+++ b/tests/test_plot_adaptive_summary.py
@@ -1,0 +1,493 @@
+"""Tests for AdaptiveSummary."""
+
+from __future__ import annotations
+
+import matplotlib
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.legend import Legend
+
+from pythermalcomfort.plots.matplotlib.adaptive_summary import AdaptiveSummary
+from pythermalcomfort.plots.matplotlib.threshold_summary import SummaryPlotResult
+
+
+@pytest.fixture(autouse=True)
+def close_all_figures():
+    yield
+    plt.close("all")
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ashrae_df() -> pd.DataFrame:
+    """Three rows that each fall into a distinct ASHRAE region.
+
+    With t_running_mean=20 → t_cmf=24.0, ce=0 (v=0.1):
+      90% band: [21.5, 26.5]
+      80% band: [20.5, 27.5]
+
+    - to=25 → in 90% (and 80%, overwritten by narrower)
+    - to=21 → in 80% only (21 < 21.5)
+    - to=19 → not acceptable (19 < 20.5)
+    """
+    return pd.DataFrame(
+        {
+            "tdb": [25.0, 21.0, 19.0],
+            "tr": [25.0, 21.0, 19.0],
+            "t_running_mean": [20.0, 20.0, 20.0],
+            "v": [0.1, 0.1, 0.1],
+        }
+    )
+
+
+@pytest.fixture
+def en_df() -> pd.DataFrame:
+    """Four rows that each fall into a distinct EN category.
+
+    With t_running_mean=20 → t_cmf=25.4, ce=0 (v=0.1):
+      Cat I:   [22.4, 27.4]
+      Cat II:  [21.4, 28.4]
+      Cat III: [20.4, 29.4]
+
+    - to=25 → Cat I
+    - to=22 → Cat II only (22 >= 21.4 but 22 < 22.4)
+    - to=21 → Cat III only (21 >= 20.4 but 21 < 21.4)
+    - to=20 → not acceptable (20 < 20.4)
+    """
+    return pd.DataFrame(
+        {
+            "tdb": [25.0, 22.0, 21.0, 20.0],
+            "tr": [25.0, 22.0, 21.0, 20.0],
+            "t_running_mean": [20.0, 20.0, 20.0, 20.0],
+            "v": [0.1, 0.1, 0.1, 0.1],
+        }
+    )
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _new_ashrae(df: pd.DataFrame) -> AdaptiveSummary:
+    return AdaptiveSummary(df).set_regions(output="acceptability", thresholds=[80, 90])
+
+
+def _new_en(df: pd.DataFrame) -> AdaptiveSummary:
+    return AdaptiveSummary(df).set_regions(
+        output="acceptability_cat", thresholds=["i", "ii", "iii"]
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Initialization
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_init_rejects_non_dataframe() -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        AdaptiveSummary([1, 2, 3])
+
+
+def test_init_rejects_empty_dataframe() -> None:
+    with pytest.raises(ValueError, match="at least one row"):
+        AdaptiveSummary(pd.DataFrame())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# set_regions validation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_set_regions_rejects_non_string_output(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(TypeError, match="output must be a string"):
+        AdaptiveSummary(ashrae_df).set_regions(output=123, thresholds=[80])
+
+
+def test_set_regions_rejects_unknown_output(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="output must be one of"):
+        AdaptiveSummary(ashrae_df).set_regions(output="unknown", thresholds=[80])
+
+
+def test_set_regions_rejects_empty_thresholds(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="at least one band key"):
+        AdaptiveSummary(ashrae_df).set_regions(output="acceptability", thresholds=[])
+
+
+def test_set_regions_rejects_invalid_ashrae_threshold(
+    ashrae_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="Invalid threshold"):
+        AdaptiveSummary(ashrae_df).set_regions(
+            output="acceptability", thresholds=[80, 99]
+        )
+
+
+def test_set_regions_rejects_invalid_en_threshold(en_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="Invalid threshold"):
+        AdaptiveSummary(en_df).set_regions(
+            output="acceptability_cat", thresholds=["iv"]
+        )
+
+
+def test_set_regions_rejects_wrong_label_count(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="labels must have length 3"):
+        AdaptiveSummary(ashrae_df).set_regions(
+            output="acceptability",
+            thresholds=[80, 90],
+            labels=["A", "B"],
+        )
+
+
+def test_set_regions_rejects_wrong_color_count(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="colors must have length 3"):
+        AdaptiveSummary(ashrae_df).set_regions(
+            output="acceptability",
+            thresholds=[80, 90],
+            colors=["#ff0000"],
+        )
+
+
+def test_set_regions_rejects_invalid_color(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="Invalid color"):
+        AdaptiveSummary(ashrae_df).set_regions(
+            output="acceptability",
+            thresholds=[80, 90],
+            colors=["red", "not_a_color", "blue"],
+        )
+
+
+def test_set_regions_rejects_missing_columns() -> None:
+    df = pd.DataFrame({"tdb": [25.0], "tr": [25.0]})
+    with pytest.raises(ValueError, match="missing required column"):
+        AdaptiveSummary(df).set_regions(output="acceptability", thresholds=[80])
+
+
+def test_plot_requires_set_regions(ashrae_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="Call set_regions"):
+        AdaptiveSummary(ashrae_df).plot()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ASHRAE 55 — percentages and labels
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ashrae_default_labels(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    expected = ["Not Acceptable", "80% Acceptability", "90% Acceptability"]
+    assert result.percentages.index.tolist() == expected
+
+
+def test_ashrae_percentages(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert result.percentages.tolist() == pytest.approx([33.3, 33.3, 33.3])
+
+
+def test_ashrae_single_band_80(ashrae_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[80])
+        .plot()
+    )
+    assert result.percentages.index.tolist() == [
+        "Not Acceptable",
+        "80% Acceptability",
+    ]
+    # to=25 and to=21 both fall inside 80% band; to=19 does not
+    assert result.percentages.tolist() == pytest.approx([33.3, 66.7])
+
+
+def test_ashrae_single_band_90(ashrae_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[90])
+        .plot()
+    )
+    assert result.percentages.index.tolist() == [
+        "Not Acceptable",
+        "90% Acceptability",
+    ]
+    # only to=25 falls inside 90% band
+    assert result.percentages.tolist() == pytest.approx([66.7, 33.3])
+
+
+def test_ashrae_custom_labels(ashrae_df: pd.DataFrame) -> None:
+    labels = ["Bad", "OK", "Great"]
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[80, 90], labels=labels)
+        .plot()
+    )
+    assert result.percentages.index.tolist() == labels
+
+
+def test_ashrae_custom_colors(ashrae_df: pd.DataFrame) -> None:
+    colors = ["#FF0000", "#00FF00", "#0000FF"]
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[80, 90], colors=colors)
+        .plot()
+    )
+    assert isinstance(result, SummaryPlotResult)
+
+
+def test_ashrae_threshold_order_independent(ashrae_df: pd.DataFrame) -> None:
+    r1 = _new_ashrae(ashrae_df).plot()
+    r2 = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[90, 80])
+        .plot()
+    )
+    assert r1.percentages.tolist() == r2.percentages.tolist()
+    assert r1.percentages.index.tolist() == r2.percentages.index.tolist()
+
+
+def test_ashrae_duplicate_thresholds_deduplicated(ashrae_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_regions(output="acceptability", thresholds=[80, 80, 90])
+        .plot()
+    )
+    assert result.percentages.index.tolist() == [
+        "Not Acceptable",
+        "80% Acceptability",
+        "90% Acceptability",
+    ]
+
+
+def test_ashrae_all_acceptable() -> None:
+    """Every data point falls within the 90% band."""
+    df = pd.DataFrame(
+        {
+            "tdb": [24.0, 25.0, 23.0],
+            "tr": [24.0, 25.0, 23.0],
+            "t_running_mean": [20.0, 20.0, 20.0],
+            "v": [0.1, 0.1, 0.1],
+        }
+    )
+    result = _new_ashrae(df).plot()
+    assert result.percentages.iloc[0] == pytest.approx(0.0)  # Not Acceptable
+    assert result.percentages.iloc[1] == pytest.approx(0.0)  # 80% only
+    assert result.percentages.iloc[2] == pytest.approx(100.0)  # 90%
+
+
+def test_ashrae_none_acceptable() -> None:
+    """Every data point falls outside all bands (t_running_mean out of range)."""
+    df = pd.DataFrame(
+        {
+            "tdb": [25.0, 26.0],
+            "tr": [25.0, 26.0],
+            "t_running_mean": [5.0, 5.0],  # below 10 → model returns NaN
+            "v": [0.1, 0.1],
+        }
+    )
+    result = _new_ashrae(df).plot()
+    assert result.percentages.iloc[0] == pytest.approx(100.0)  # all Not Acceptable
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EN 16798 — percentages and labels
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_en_default_labels(en_df: pd.DataFrame) -> None:
+    result = _new_en(en_df).plot()
+    expected = ["Not Acceptable", "Category III", "Category II", "Category I"]
+    assert result.percentages.index.tolist() == expected
+
+
+def test_en_percentages(en_df: pd.DataFrame) -> None:
+    result = _new_en(en_df).plot()
+    assert result.percentages.tolist() == pytest.approx([25.0, 25.0, 25.0, 25.0])
+
+
+def test_en_subset_two_bands(en_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(en_df)
+        .set_regions(output="acceptability_cat", thresholds=["i", "ii"])
+        .plot()
+    )
+    assert result.percentages.index.tolist() == [
+        "Not Acceptable",
+        "Category II",
+        "Category I",
+    ]
+    # to=21 and to=20 are both outside Cat II → Not Acceptable
+    assert result.percentages.tolist() == pytest.approx([50.0, 25.0, 25.0])
+
+
+def test_en_single_band_cat_iii(en_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(en_df)
+        .set_regions(output="acceptability_cat", thresholds=["iii"])
+        .plot()
+    )
+    assert result.percentages.index.tolist() == [
+        "Not Acceptable",
+        "Category III",
+    ]
+    # to=25,22,21 all in Cat III; to=20 not
+    assert result.percentages.tolist() == pytest.approx([25.0, 75.0])
+
+
+def test_en_threshold_order_independent(en_df: pd.DataFrame) -> None:
+    r1 = _new_en(en_df).plot()
+    r2 = (
+        AdaptiveSummary(en_df)
+        .set_regions(output="acceptability_cat", thresholds=["i", "iii", "ii"])
+        .plot()
+    )
+    assert r1.percentages.tolist() == r2.percentages.tolist()
+    assert r1.percentages.index.tolist() == r2.percentages.index.tolist()
+
+
+def test_en_case_insensitive_keys(en_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(en_df)
+        .set_regions(output="acceptability_cat", thresholds=["I", "II", "III"])
+        .plot()
+    )
+    expected = ["Not Acceptable", "Category III", "Category II", "Category I"]
+    assert result.percentages.index.tolist() == expected
+
+
+def test_en_custom_labels(en_df: pd.DataFrame) -> None:
+    labels = ["Fail", "OK", "Good", "Excellent"]
+    result = (
+        AdaptiveSummary(en_df)
+        .set_regions(
+            output="acceptability_cat",
+            thresholds=["i", "ii", "iii"],
+            labels=labels,
+        )
+        .plot()
+    )
+    assert result.percentages.index.tolist() == labels
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Plot rendering
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_plot_returns_summary_plot_result(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert isinstance(result, SummaryPlotResult)
+
+
+def test_plot_uses_provided_axis(ashrae_df: pd.DataFrame) -> None:
+    fig, ax = plt.subplots()
+    result = _new_ashrae(ashrae_df).plot(ax=ax)
+    assert result.ax is ax
+    assert result.fig is fig
+
+
+def test_plot_creates_figure_when_no_axis(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert result.fig is not None
+    assert result.ax is not None
+
+
+def test_plot_vertical_mode(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot(vertical=True)
+    assert isinstance(result, SummaryPlotResult)
+    assert len(result.artists) > 0
+
+
+def test_plot_legend_shown_by_default(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert isinstance(result.legend, Legend)
+
+
+def test_plot_legend_none_when_disabled(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot(legend=False)
+    assert result.legend is None
+
+
+def test_plot_title_rendered(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot(title="Test Title")
+    assert result.ax.get_title() == "Test Title"
+
+
+def test_plot_bar_kws_forwarded(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot(bar_kws={"alpha": 0.5})
+    patch = result.artists[0].patches[0]
+    assert patch.get_alpha() == pytest.approx(0.5)
+
+
+def test_plot_has_artists(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert len(result.artists) > 0
+
+
+def test_plot_title_does_not_overlap_horizontal_legend(
+    ashrae_df: pd.DataFrame,
+) -> None:
+    result = _new_ashrae(ashrae_df).plot(title="ASHRAE Summary")
+    result.fig.canvas.draw()
+    renderer = result.fig.canvas.get_renderer()
+    title_bbox = result.ax.title.get_window_extent(renderer)
+    legend_bbox = result.legend.get_window_extent(renderer)
+    assert title_bbox.y0 > legend_bbox.y1
+
+
+def test_plot_title_does_not_overlap_vertical_legend(
+    en_df: pd.DataFrame,
+) -> None:
+    result = _new_en(en_df).plot(vertical=True, title="EN Summary (Vertical)")
+    result.fig.canvas.draw()
+    renderer = result.fig.canvas.get_renderer()
+    title_bbox = result.ax.title.get_window_extent(renderer)
+    legend_bbox = result.legend.get_window_extent(renderer)
+    assert title_bbox.y0 > legend_bbox.y1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Percentages consistency
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ashrae_percentages_sum_to_100(ashrae_df: pd.DataFrame) -> None:
+    result = _new_ashrae(ashrae_df).plot()
+    assert result.percentages.sum() == pytest.approx(100.0, abs=0.5)
+
+
+def test_en_percentages_sum_to_100(en_df: pd.DataFrame) -> None:
+    result = _new_en(en_df).plot()
+    assert result.percentages.sum() == pytest.approx(100.0, abs=0.5)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# set_params
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_set_params_returns_self(ashrae_df: pd.DataFrame) -> None:
+    builder = AdaptiveSummary(ashrae_df)
+    assert builder.set_params(limit_inputs=False) is builder
+
+
+def test_set_params_limit_inputs_false(ashrae_df: pd.DataFrame) -> None:
+    result = (
+        AdaptiveSummary(ashrae_df)
+        .set_params(limit_inputs=False)
+        .set_regions(output="acceptability", thresholds=[80, 90])
+        .plot()
+    )
+    assert isinstance(result, SummaryPlotResult)
+    assert result.percentages.sum() == pytest.approx(100.0, abs=0.5)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Method chaining
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_set_regions_returns_self(ashrae_df: pd.DataFrame) -> None:
+    builder = AdaptiveSummary(ashrae_df)
+    returned = builder.set_regions(output="acceptability", thresholds=[80, 90])
+    assert returned is builder

--- a/tests/test_plot_threshold_summary.py
+++ b/tests/test_plot_threshold_summary.py
@@ -8,9 +8,9 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.legend import Legend
 
-from pythermalcomfort.plots.matplotlib.summary import (
-    SummaryPlot,
+from pythermalcomfort.plots.matplotlib.threshold_summary import (
     SummaryPlotResult,
+    ThresholdSummary,
 )
 
 
@@ -31,28 +31,28 @@ def pmv_df() -> pd.DataFrame:
     )
 
 
-def _new_summary(pmv_df: pd.DataFrame) -> SummaryPlot:
-    return SummaryPlot(pmv_df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
+def _new_summary(pmv_df: pd.DataFrame) -> ThresholdSummary:
+    return ThresholdSummary(pmv_df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
 
 
 def test_init_rejects_non_dataframe() -> None:
     with pytest.raises(TypeError, match="pandas DataFrame"):
-        SummaryPlot([1, 2, 3])
+        ThresholdSummary([1, 2, 3])
 
 
 def test_init_rejects_empty_dataframe() -> None:
     with pytest.raises(ValueError, match="at least one row"):
-        SummaryPlot(pd.DataFrame())
+        ThresholdSummary(pd.DataFrame())
 
 
 def test_plot_requires_set_regions(pmv_df: pd.DataFrame) -> None:
     with pytest.raises(ValueError, match="Call set_regions"):
-        SummaryPlot(pmv_df).plot()
+        ThresholdSummary(pmv_df).plot()
 
 
 def test_set_regions_rejects_empty_output_name(pmv_df: pd.DataFrame) -> None:
     with pytest.raises(ValueError, match="non-empty string"):
-        SummaryPlot(pmv_df).set_regions(output="   ", thresholds=[-0.5, 0.5])
+        ThresholdSummary(pmv_df).set_regions(output="   ", thresholds=[-0.5, 0.5])
 
 
 def test_set_regions_rejects_missing_output_column(pmv_df: pd.DataFrame) -> None:
@@ -60,12 +60,12 @@ def test_set_regions_rejects_missing_output_column(pmv_df: pd.DataFrame) -> None
         ValueError,
         match="output column 'utci' was not found in the DataFrame.",
     ):
-        SummaryPlot(pmv_df).set_regions(output="utci", thresholds=[9, 26])
+        ThresholdSummary(pmv_df).set_regions(output="utci", thresholds=[9, 26])
 
 
 def test_set_regions_rejects_wrong_label_count(pmv_df: pd.DataFrame) -> None:
     with pytest.raises(ValueError, match="labels must have length 3"):
-        SummaryPlot(pmv_df).set_regions(
+        ThresholdSummary(pmv_df).set_regions(
             output="pmv",
             thresholds=[-0.5, 0.5],
             labels=["Cold", "Hot"],
@@ -74,7 +74,7 @@ def test_set_regions_rejects_wrong_label_count(pmv_df: pd.DataFrame) -> None:
 
 def test_set_regions_rejects_wrong_color_count(pmv_df: pd.DataFrame) -> None:
     with pytest.raises(ValueError, match="colors must have length 3"):
-        SummaryPlot(pmv_df).set_regions(
+        ThresholdSummary(pmv_df).set_regions(
             output="pmv",
             thresholds=[-0.5, 0.5],
             colors=["#4c78a8", "#e15759"],
@@ -107,7 +107,7 @@ def test_plot_uses_compact_default_figsize(pmv_df: pd.DataFrame) -> None:
 
 def test_vertical_empty_labels_uses_compact_xlim(pmv_df: pd.DataFrame) -> None:
     result = (
-        SummaryPlot(pmv_df)
+        ThresholdSummary(pmv_df)
         .set_regions(output="pmv", thresholds=[-0.5, 0.5], labels=[])
         .plot(vertical=True, legend=False)
     )
@@ -158,7 +158,7 @@ def test_plot_returns_percentages(pmv_df: pd.DataFrame) -> None:
 def test_plot_uses_custom_labels_when_provided(pmv_df: pd.DataFrame) -> None:
     custom_labels = ["Cold", "Neutral", "Hot"]
     result = (
-        SummaryPlot(pmv_df)
+        ThresholdSummary(pmv_df)
         .set_regions(
             output="pmv",
             thresholds=[-0.5, 0.5],
@@ -178,7 +178,7 @@ def test_plot_supports_utci_like_existing_column() -> None:
         }
     )
 
-    result = SummaryPlot(df).set_regions(output="utci", thresholds=[9, 26]).plot()
+    result = ThresholdSummary(df).set_regions(output="utci", thresholds=[9, 26]).plot()
 
     expected_labels = ["UTCI < 9", "9 ≤ UTCI < 26", "UTCI ≥ 26"]
     assert result.percentages.index.tolist() == expected_labels
@@ -189,20 +189,20 @@ def test_set_regions_rejects_non_numeric_output_values() -> None:
     df = pd.DataFrame({"pmv": [0.1, "bad", 0.2]})
 
     with pytest.raises(ValueError, match="non-numeric"):
-        SummaryPlot(df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
+        ThresholdSummary(df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
 
 
 def test_set_regions_rejects_non_finite_output_values() -> None:
     df = pd.DataFrame({"pmv": [0.1, float("inf"), 0.2]})
 
     with pytest.raises(ValueError, match="non-finite"):
-        SummaryPlot(df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
+        ThresholdSummary(df).set_regions(output="pmv", thresholds=[-0.5, 0.5])
 
 
 def test_summary_with_custom_labels() -> None:
     df = pd.DataFrame({"pmv": [0.7, -0.3, 0.1, -0.8, 1.2]})
     result = (
-        SummaryPlot(df)
+        ThresholdSummary(df)
         .set_regions(
             output="pmv",
             thresholds=[-0.5, 0.5],
@@ -216,7 +216,9 @@ def test_summary_with_custom_labels() -> None:
 
 def test_summary_handles_numeric_string_column() -> None:
     df = pd.DataFrame({"pmv": ["0.7", "-0.3", "0.1", "-0.8", "1.2"]})
-    result = SummaryPlot(df).set_regions(output="pmv", thresholds=[-0.5, 0.5]).plot()
+    result = (
+        ThresholdSummary(df).set_regions(output="pmv", thresholds=[-0.5, 0.5]).plot()
+    )
     assert isinstance(result, SummaryPlotResult)
     assert result.percentages.sum() > 99.9
 
@@ -266,7 +268,7 @@ def test_plot_result_has_no_data_attribute(pmv_df: pd.DataFrame) -> None:
 
 def test_set_regions_empty_labels_suppresses_label_text(pmv_df: pd.DataFrame) -> None:
     result = (
-        SummaryPlot(pmv_df)
+        ThresholdSummary(pmv_df)
         .set_regions(output="pmv", thresholds=[-0.5, 0.5], labels=[])
         .plot()
     )
@@ -279,7 +281,7 @@ def test_empty_labels_suppresses_label_text_via_thresholds(
     pmv_df: pd.DataFrame,
 ) -> None:
     result = (
-        SummaryPlot(pmv_df)
+        ThresholdSummary(pmv_df)
         .set_regions(output="pmv", thresholds=[-0.5, 0.5], labels=[])
         .plot()
     )


### PR DESCRIPTION
## Summary

This PR introduces `AdaptiveSummary`, a new summary plot class that visualizes the distribution of data points across adaptive comfort bands (ASHRAE / EN). The existing `SummaryPlot` is renamed to `ThresholdSummary` to clearly distinguish the two summary plot types.

## Motivation

As we discussed in the previous meeting, implementing adaptive summaries within SummaryPlot or distributing them across different classes were both acceptable approaches. The key point was that the new adaptive summaries needed to maintain consistency with existing usage patterns to minimize the learning effort for users.

After trying various solutions, it became clear that simultaneously supporting threshold and adaptive summaries within SummaryPlot, while keeping the same usage pattern, would inevitably introduce excessive helper functions or nested logic, negatively impacting readability and maintainability.

In contrast, distributing them across different classes, while creating more files, eliminates the need to modify existing code; new code can be added directly and each file and class has a clearly defined function.

## Changes

### Renamed

- `SummaryPlot` → `ThresholdSummary` (file renamed from `summary.py` to `threshold_summary.py`)
- Class name and return type annotations updated (3 occurrences)
- All internal logic, helper functions, and `SummaryPlotResult` remain unchanged

### Added

- `adaptive_summary.py` — new `AdaptiveSummary` class with:
    - `set_regions(output, thresholds, labels, colors)` — selects the adaptive model via output naming `convention`:
        - `"acceptability"` → ASHRAE (thresholds: 80, 90)
        - `"acceptability_cat"` → EN (thresholds: "i", "ii", "iii")
    - `plot()` — renders a stacked bar chart (horizontal or vertical) with the same API and visual style as `ThresholdSummary`
    - Categorization logic assigns each row to the narrowest band it satisfies (widest-first iteration with narrower bands overwriting)
- `test_plot_adaptive_summary.py`

### Updated

- `__init__.py` — exports `AdaptiveSummary` and `ThresholdSummary` (replaces `SummaryPlot`)
- `test_plot_summary.py` → `test_plot_threshold_summary.py` — all `SummaryPlot` references replaced with `ThresholdSummary`

### Usage

```python
import pandas as pd
from matplotlib import pyplot as plt
from pythermalcomfort.plots.matplotlib import AdaptiveSummary

df = pd.DataFrame({
    "tdb": [25, 28, 22, 30, 26],
    "tr":  [25, 28, 22, 30, 26],
    "t_running_mean": [20, 22, 15, 25, 18],
    "v":   [0.1, 0.3, 0.1, 0.5, 0.2],
})

result = (
    AdaptiveSummary(df)
    .set_regions(output="acceptability", thresholds=[80, 90])
    .plot()
)
plt.show()

result = (
    AdaptiveSummary(df)
    .set_regions(output="acceptability_cat", thresholds=["i", "ii","iii"])
    .plot()
)
plt.show()
```