### PR TITLE
fix(plots): map RegionsConfig labels/colors by band key

### DIFF
--- a/pythermalcomfort/plots/matplotlib/adaptive.py
+++ b/pythermalcomfort/plots/matplotlib/adaptive.py
@@ -413,14 +413,20 @@ class AdaptivePlot(BasePlot):
         if cfg is not None and cfg.show is not None:
             show_set = set(cfg.show)
             visible_specs = [s for s in all_specs if s.key in show_set]
+            # ``labels``/``colors`` are positional against the caller's
+            # ``show`` order, while bands are always rendered in canonical
+            # (widest to narrowest) order, so map overrides by band key.
+            override_index = {key: i for i, key in enumerate(cfg.show)}
         else:
             visible_specs = list(all_specs)
+            override_index = {spec.key: i for i, spec in enumerate(visible_specs)}
 
         resolved: list[_ResolvedBand] = []
-        for i, spec in enumerate(visible_specs):
+        for spec in visible_specs:
             label = spec.default_label
             color = spec.default_color
             if cfg is not None:
+                i = override_index[spec.key]
                 if cfg.labels is not None:
                     label = str(cfg.labels[i])
                 if cfg.colors is not None:

--- a/tests/test_plot_adaptive.py
+++ b/tests/test_plot_adaptive.py
@@ -228,6 +228,27 @@ def test_set_regions_returns_self_for_chaining() -> None:
     assert plot.set_regions(show=["90"]) is plot
 
 
+def test_set_regions_labels_follow_show_order() -> None:
+    config = RegionsConfig(
+        show=["90", "80"],
+        labels=["Narrow band", "Wide band"],
+        colors=["#ff0000", "#00ff00"],
+    )
+    plot = AdaptivePlot(adaptive_ashrae).set_regions(show=config)
+    resolved = {b.spec.key: (b.label, b.color) for b in plot._resolve_bands()}
+    assert resolved["90"] == ("Narrow band", "#ff0000")
+    assert resolved["80"] == ("Wide band", "#00ff00")
+
+
+def test_set_regions_labels_follow_show_order_en() -> None:
+    plot = AdaptivePlot(adaptive_en).set_regions(
+        show=["cat_i", "cat_iii"], labels=["First", "Third"]
+    )
+    resolved = {b.spec.key: b.label for b in plot._resolve_bands()}
+    assert resolved["cat_i"] == "First"
+    assert resolved["cat_iii"] == "Third"
+
+
 # ── plot — ASHRAE ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
# Description

`AdaptivePlot._resolve_bands()` filtered the visible bands through a `set`, so they were always rebuilt in canonical (widest to narrowest) order, while `RegionsConfig.labels`/`colors` were indexed positionally against the caller's `show` order. Passing `show` out of canonical order therefore attached each label/color to the wrong band. Overrides are now looked up by band key, so they follow the order the caller wrote.

Fixes #365

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

# How Has This Been Tested?

Two new tests in `tests/test_plot_adaptive.py` (`test_set_regions_labels_follow_show_order`, ASHRAE, and `..._en`) assert the resolved label/color per band key. Both fail on `master` (e.g. `assert ('Wide band', '#00ff00') == ('Narrow band', '#ff0000')`) and pass with the fix. `tests/test_plot_adaptive.py` 63 passed; `test_plot_summary.py` + `test_plot_threshold.py` 67 passed. `ruff check` and `ruff format --check` clean on both changed files.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed adaptive comfort plots so custom labels and colours remain associated with the correct comfort bands.
  - Preserved the requested band selection order while rendering bands consistently.
  - Added validation to reject duplicate band selections.
  - Improved consistency for both ASHRAE and EN adaptive plot configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->