### PR TITLE
fix(tests): pin validation-data-comfort-models fixtures to v1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ pre-commit run --all-files
 serialize formats on its own (via `pre_n`'s `optional_value`) — so in the normal case
 you don't need to touch git yourself after running it, just push.
 
+0. **Check the `validation-data-comfort-models` pin is current.** `tests/conftest.py`'s
+   `unit_test_data_prefix` is pinned to a tag of that repo, not `main`. Compare it against
+   [that repo's latest tag](https://github.com/FedericoTartarini/validation-data-comfort-models/tags)
+   and its `CHANGELOG.md`; if behind, bump the pin and re-run the affected tests before
+   proceeding. See `CONTRIBUTING.rst`'s "Keeping the validation-data-comfort-models pin
+   current" for details — don't ship a release still pointed at a stale tag.
+
 1. **Update ``CHANGELOG.rst``** with all changes since the last release, then commit.
 
 2. **On `development`**, cut an RC (deploys to TestPyPI for verification). Pick

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,6 +122,11 @@ When opening a pull request, include:
 * Relevant documentation updates (docstrings or docs/).
 * A CHANGELOG entry (if applicable).
 * Add yourself to AUTHORS.rst (optional).
+* If your change touches ``tests/conftest.py``'s ``unit_test_data_prefix``
+  or any test relying on `validation-data-comfort-models
+  <https://github.com/FedericoTartarini/validation-data-comfort-models>`_,
+  check that repo's latest tag and bump the pin if a newer one exists —
+  see "Keeping the validation-data-comfort-models pin current" below.
 
 Contributing a New Function
 ===========================
@@ -295,6 +300,34 @@ Failing to do this means ``development`` will be behind ``master`` and the next
 RC tag will be rejected by the CI ``merge-base`` check.
 
 See ``CLAUDE.md`` for the full step-by-step release process.
+
+Keeping the validation-data-comfort-models pin current
+--------------------------------------------------------
+
+Test fixtures are fetched from `validation-data-comfort-models
+<https://github.com/FedericoTartarini/validation-data-comfort-models>`_ at a
+tagged release, pinned via ``unit_test_data_prefix`` in ``tests/conftest.py``
+(e.g. ``.../validation-data-comfort-models/v1.0.0/``). It is **not** pinned to
+``main``, on purpose: a fixture change there would otherwise silently change
+what our CI validates against, on every branch and PR, before anyone here
+reviewed it.
+
+This means the pin can drift behind that repo's actual latest tag. Before
+cutting a pythermalcomfort release, and whenever a PR here depends on new or
+changed reference data:
+
+1. Check the `latest tag <https://github.com/FedericoTartarini/validation-data-comfort-models/tags>`_
+   and its `CHANGELOG.md <https://github.com/FedericoTartarini/validation-data-comfort-models/blob/main/CHANGELOG.md>`_.
+2. If it's newer than the tag in ``tests/conftest.py``, bump the pin in the
+   same PR and note in the PR description which changelog entries motivated
+   the bump.
+3. Re-run the affected tests (e.g. ``pytest tests/test_phs.py``) against the
+   new tag before merging — a MAJOR bump there (see that repo's README for
+   its semver rules) can mean renamed/removed keys that break our assertions.
+
+Running against a tag that's several releases behind is treated as a bug to
+flag/fix, not a "leave it be" — open an issue if you notice this and can't fix
+it in the same PR.
 
 8) Formatting, linting and tests locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,11 @@ import requests
 # without needing to import them (pytest will automatically discover them).
 
 
-unit_test_data_prefix = "https://raw.githubusercontent.com/FedericoTartarini/validation-data-comfort-models/main/"
+# Pinned to a tagged release rather than `main` so that changes to the
+# validation-data-comfort-models repo can't silently break this repo's CI
+# before they've been reviewed and the pin deliberately bumped. See that
+# repo's CHANGELOG.md when bumping this tag.
+unit_test_data_prefix = "https://raw.githubusercontent.com/FedericoTartarini/validation-data-comfort-models/v1.0.0/"
 
 
 class Urls(Enum):


### PR DESCRIPTION
## Summary
- Fixture URLs in `tests/conftest.py` tracked `validation-data-comfort-models`'s `main` branch directly, so any commit there — including a bad one — could silently change what our CI validates against on every branch/PR, before anyone reviewed it.
- This is exactly what happened with the `ts_phs` boundary-test row (`tr=61, tdb=20`), which checked raw `tr > 60` instead of the actual `(tr - tdb) > 60` limit and had already been fixed there.
- Pin `unit_test_data_prefix` to the new `v1.0.0` tag instead. That repo now has a `CHANGELOG.md` and a documented [semver release process](https://github.com/FedericoTartarini/validation-data-comfort-models#versioning) describing notable changes; bump the tag deliberately when picking up new fixture data.
- **Also added process docs** so the pin doesn't quietly drift behind that repo's latest tag:
  - `CONTRIBUTING.rst`: new "Keeping the validation-data-comfort-models pin current" section, plus a PR-checklist bullet.
  - `CLAUDE.md`: a pre-release step to check for a newer tag before cutting a pythermalcomfort release.

## Test plan
- Ran `pytest tests/test_phs.py` locally against the pinned tag: 9 passed, 1 known xfail (unrelated), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)