### PR TITLE
Release 4.4.1: fix PHS applicability limits and add 2023 minute-1 skin temp override

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "4.4.0"
+current_version = "4.4.1rc1"
 commit = true
 tag = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:rc(?P<pre_n>\\d+))?"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+4.4.1 (2026-08-18)
+------------------
 
 * Fixed the ``phs`` applicability limits (`#225 <https://github.com/pythermalcomfort/pythermalcomfort/issues/225>`_):
     - the ``tr`` limit is now checked against ``ISO 7933 Annex A, Table A.1``'s actual

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixed the ``phs`` applicability limits (`#225 <https://github.com/pythermalcomfort/pythermalcomfort/issues/225>`_):
+    - the ``tr`` limit is now checked against ``ISO 7933 Annex A, Table A.1``'s actual
+      ``0 < (tr - tdb) < 60`` range, instead of checking raw ``tr`` against ``(0, 60)``.
+    - the metabolic rate limit is now standard-specific: ``100-450 W/m2`` (1.7-7.5 met)
+      for the 2004 standard, ``56-250 W/m2`` (0.96-4.3 met) for the 2023 standard,
+      instead of always using the 2004 range.
+* Added the ISO 7933:2023 Annex E minute-1 skin temperature special case to the
+  ``phs`` 2023 model (``t_sk`` is forced to its equilibrium value on the first
+  minute), matching the standard's own reference program. This special case is
+  not present in the 2004 edition.
+
 4.4.0 (2026-07-25)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = "pythermalcomfort"
 year = "2025"
 author = "Federico Tartarini"
 project_copyright = f"{year}, {author}"
-version = release = "4.4.0"
+version = release = "4.4.1rc1"
 
 autodoc_typehints = "none"
 

--- a/pythermalcomfort/__init__.py
+++ b/pythermalcomfort/__init__.py
@@ -4,4 +4,4 @@ This package provides comprehensive tools for calculating thermal comfort indice
 heat/cold stress metrics, and thermophysiological responses using multiple models.
 """
 
-__version__: str = "4.4.0"
+__version__: str = "4.4.1rc1"

--- a/pythermalcomfort/models/ireq.py
+++ b/pythermalcomfort/models/ireq.py
@@ -33,9 +33,9 @@ def ireq(
     Parameters
     ----------
     tdb : float or list of floats
-        Dry bulb air temperature, [deg C].
+        Dry bulb air temperature, [°C].
     tr : float or list of floats
-        Mean radiant temperature, [deg C].
+        Mean radiant temperature, [°C].
     vr : float or list of floats
         Relative air speed, [m/s].
     rh : float or list of floats
@@ -58,7 +58,7 @@ def ireq(
         .. note::
             The ISO 11079 applicability limits used by this function are
             58 <= met [W/m2] <= 400 after converting the input metabolic rate
-            from met to W/m2, tdb <= 10 [deg C], 0.4 <= vr [m/s] <= 18, and
+            from met to W/m2, tdb <= 10 [°C], 0.4 <= vr [m/s] <= 18, and
             minimum_walking_speed <= walk_sp [m/s] <= 1.2, where
             minimum_walking_speed = min(0.0052 * (met [W/m2] - 58), 1.2).
 

--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -77,8 +77,10 @@ def phs(
             function returns nan. If False returns values even if input values are
             outside the applicability limits of the model.
 
-            The 7933 limits are 15 < tdb [°C] < 50, 0 < tr [°C] < 60,
-            0 < vr [m/s] < 3, 1.7 < met [met] < 7.5, and 0.1 < clo [clo] < 1.
+            The 7933 limits are 15 < tdb [°C] < 50, 0 < (tr - tdb) [°C] < 60,
+            0 < vr [m/s] < 3, and 0.1 < clo [clo] < 1. The metabolic rate limit is
+            standard-specific: 1.7 < met [met] < 7.5 (100-450 W/m2) in the 2004
+            standard, and 0.96 < met [met] < 4.3 (56-250 W/m2) in the 2023 standard.
 
     i_mst : float, optional
         Static moisture permeability index, [dimensionless]. Defaults to 0.38.
@@ -423,14 +425,18 @@ def phs(
     }
 
     if limit_inputs:
-        # ISO 7933 Annex A applicability limits. p_a lower bound is 0.5 in the
-        # 2023 revision and 0 in the 2004 edition; all other limits are identical.
+        # ISO 7933 Annex A, Table A.1 applicability limits. p_a lower bound is 0.5 in
+        # the 2023 revision and 0 in the 2004 edition. The metabolic rate range is also
+        # standard-specific: 100-450 W/m2 in the 2004 edition, 56-250 W/m2 in the 2023
+        # edition. All other limits are identical, including the range on (tr - tdb),
+        # not on tr alone.
         p_a_lower = 0.5 if model == Models.iso_7933_2023.value else 0
+        met_range = (56, 250) if model == Models.iso_7933_2023.value else (100, 450)
         tdb_valid = valid_range(tdb, (15.0, 50.0))
-        tr_valid = valid_range(tr, (0.0, 60.0))
+        tr_valid = valid_range(tr - tdb, (0.0, 60.0))
         v_valid = valid_range(v, (0.0, 3.0))
         p_a_valid = valid_range(p_a, (p_a_lower, 4.5))
-        met_valid = valid_range(met, (100, 450))
+        met_valid = valid_range(met, met_range)
         clo_valid = valid_range(clo, (0.1, 1.0))
         all_valid = ~(
             np.isnan(tdb_valid)
@@ -711,6 +717,11 @@ def _phs_optimized_scalar(
 
         # skin temperature [C]
         t_sk = t_sk0 * const_t_sk + t_sk_eq * (1 - const_t_sk)
+        if time == 1 and model_code == _MODEL_2023:
+            # ISO 7933:2023 Annex E forces the skin temperature to its equilibrium
+            # value on the first minute, removing the exponential lag for that step.
+            # This special case is not present in the 2004 Annex E reference code.
+            t_sk = t_sk_eq
         # Saturated water vapour pressure at the surface of the skin
         p_sk = 0.6105 * math.exp(17.27 * t_sk / (t_sk + 237.3))
         t_cl = tr + 0.1  # clothing surface temperature

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(*names: str, encoding: str = "utf8") -> str:
 
 setup(
     name="pythermalcomfort",
-    version="4.4.0",
+    version="4.4.1rc1",
     license="MIT",
     description=(
         "pythermalcomfort is a comprehensive toolkit for calculating "


### PR DESCRIPTION
## Summary
- Fixed `phs()` applicability limits (#225): `tr` is now validated as `(tr - tdb)` against ISO 7933 Annex A Table A.1's `(0, 60)` range instead of raw `tr`, and the metabolic rate range is now standard-specific (`100-450 W/m2` for 7933-2004, `56-250 W/m2` for 7933-2023) instead of always using the 2004 range.
- Added the ISO 7933:2023 Annex E minute-1 skin temperature special case (`t_sk` forced to `t_sk_eq` on the first minute), confirmed against the standard's own reference program and not present in the 2004 edition.
- Both changes confirmed by reading the ISO 7933:2004 and ISO/FDIS 7933:2023 PDF text directly (Annex A formulas + Annex E reference programs) — see #217, #223, #225.

## Test plan
- `pytest tests/` — 501 passed, 1 expected xfail (known, separately-tracked case-3 discrepancy in #217/#223)
- `ruff check` / `ruff format --check` — clean
- Verified on TestPyPI as `v4.4.1rc1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)