### PR TITLE
Release 4.4.2: pin validation-data tag + Copilot follow-ups on phs fix

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "4.4.1"
+current_version = "4.4.2rc1"
 commit = true
 tag = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:rc(?P<pre_n>\\d+))?"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Pinned ``tests/conftest.py``'s ``validation-data-comfort-models`` fixture URL to the
+  ``v1.0.0`` tag instead of ``main``, so upstream fixture changes can't silently affect
+  CI before the pin is deliberately bumped and reviewed. See ``CONTRIBUTING.rst``'s
+  "Keeping the validation-data-comfort-models pin current" section.
+* Addressed Copilot review feedback on the 4.4.1 ``phs`` fix: pass ``param_name``
+  explicitly to ``valid_range()`` for the ``(tr - tdb)`` check, and added regression
+  tests for the applicability-limit and minute-1 skin-temperature behavior.
+
 4.4.1 (2026-08-18)
 ------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,13 @@ pre-commit run --all-files
 serialize formats on its own (via `pre_n`'s `optional_value`) — so in the normal case
 you don't need to touch git yourself after running it, just push.
 
+0. **Check the `validation-data-comfort-models` pin is current.** `tests/conftest.py`'s
+   `unit_test_data_prefix` is pinned to a tag of that repo, not `main`. Compare it against
+   [that repo's latest tag](https://github.com/FedericoTartarini/validation-data-comfort-models/tags)
+   and its `CHANGELOG.md`; if behind, bump the pin and re-run the affected tests before
+   proceeding. See `CONTRIBUTING.rst`'s "Keeping the validation-data-comfort-models pin
+   current" for details — don't ship a release still pointed at a stale tag.
+
 1. **Update ``CHANGELOG.rst``** with all changes since the last release, then commit.
 
 2. **On `development`**, cut an RC (deploys to TestPyPI for verification). Pick

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,6 +122,11 @@ When opening a pull request, include:
 * Relevant documentation updates (docstrings or docs/).
 * A CHANGELOG entry (if applicable).
 * Add yourself to AUTHORS.rst (optional).
+* If your change touches ``tests/conftest.py``'s ``unit_test_data_prefix``
+  or any test relying on `validation-data-comfort-models
+  <https://github.com/FedericoTartarini/validation-data-comfort-models>`_,
+  check that repo's latest tag and bump the pin if a newer one exists —
+  see "Keeping the validation-data-comfort-models pin current" below.
 
 Contributing a New Function
 ===========================
@@ -295,6 +300,34 @@ Failing to do this means ``development`` will be behind ``master`` and the next
 RC tag will be rejected by the CI ``merge-base`` check.
 
 See ``CLAUDE.md`` for the full step-by-step release process.
+
+Keeping the validation-data-comfort-models pin current
+--------------------------------------------------------
+
+Test fixtures are fetched from `validation-data-comfort-models
+<https://github.com/FedericoTartarini/validation-data-comfort-models>`_ at a
+tagged release, pinned via ``unit_test_data_prefix`` in ``tests/conftest.py``
+(e.g. ``.../validation-data-comfort-models/v1.0.0/``). It is **not** pinned to
+``main``, on purpose: a fixture change there would otherwise silently change
+what our CI validates against, on every branch and PR, before anyone here
+reviewed it.
+
+This means the pin can drift behind that repo's actual latest tag. Before
+cutting a pythermalcomfort release, and whenever a PR here depends on new or
+changed reference data:
+
+1. Check the `latest tag <https://github.com/FedericoTartarini/validation-data-comfort-models/tags>`_
+   and its `CHANGELOG.md <https://github.com/FedericoTartarini/validation-data-comfort-models/blob/main/CHANGELOG.md>`_.
+2. If it's newer than the tag in ``tests/conftest.py``, bump the pin in the
+   same PR and note in the PR description which changelog entries motivated
+   the bump.
+3. Re-run the affected tests (e.g. ``pytest tests/test_phs.py``) against the
+   new tag before merging — a MAJOR bump there (see that repo's README for
+   its semver rules) can mean renamed/removed keys that break our assertions.
+
+Running against a tag that's several releases behind is treated as a bug to
+flag/fix, not a "leave it be" — open an issue if you notice this and can't fix
+it in the same PR.
 
 8) Formatting, linting and tests locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = "pythermalcomfort"
 year = "2025"
 author = "Federico Tartarini"
 project_copyright = f"{year}, {author}"
-version = release = "4.4.1"
+version = release = "4.4.2rc1"
 
 autodoc_typehints = "none"
 

--- a/pythermalcomfort/__init__.py
+++ b/pythermalcomfort/__init__.py
@@ -4,4 +4,4 @@ This package provides comprehensive tools for calculating thermal comfort indice
 heat/cold stress metrics, and thermophysiological responses using multiple models.
 """
 
-__version__: str = "4.4.1"
+__version__: str = "4.4.2rc1"

--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -433,7 +433,7 @@ def phs(
         p_a_lower = 0.5 if model == Models.iso_7933_2023.value else 0
         met_range = (56, 250) if model == Models.iso_7933_2023.value else (100, 450)
         tdb_valid = valid_range(tdb, (15.0, 50.0))
-        tr_valid = valid_range(tr - tdb, (0.0, 60.0))
+        tr_valid = valid_range(tr - tdb, (0.0, 60.0), param_name="tr - tdb")
         v_valid = valid_range(v, (0.0, 3.0))
         p_a_valid = valid_range(p_a, (p_a_lower, 4.5))
         met_valid = valid_range(met, met_range)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(*names: str, encoding: str = "utf8") -> str:
 
 setup(
     name="pythermalcomfort",
-    version="4.4.1",
+    version="4.4.2rc1",
     license="MIT",
     description=(
         "pythermalcomfort is a comprehensive toolkit for calculating "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,11 @@ import requests
 # without needing to import them (pytest will automatically discover them).
 
 
-unit_test_data_prefix = "https://raw.githubusercontent.com/FedericoTartarini/validation-data-comfort-models/main/"
+# Pinned to a tagged release rather than `main` so that changes to the
+# validation-data-comfort-models repo can't silently break this repo's CI
+# before they've been reviewed and the pin deliberately bumped. See that
+# repo's CHANGELOG.md when bumping this tag.
+unit_test_data_prefix = "https://raw.githubusercontent.com/FedericoTartarini/validation-data-comfort-models/v1.0.0/"
 
 
 class Urls(Enum):

--- a/tests/test_phs.py
+++ b/tests/test_phs.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from pythermalcomfort.models import phs
@@ -6,7 +8,8 @@ from tests.conftest import Urls, retrieve_reference_table, validate_result
 
 
 def test_phs(get_test_url, retrieve_data) -> None:
-    """Test that the function calculates the Predicted Heat Strain (PHS) correctly for various inputs."""
+    """Test that the function calculates the Predicted Heat Strain (PHS) correctly for
+    various inputs."""
     reference_table = retrieve_reference_table(
         get_test_url,
         retrieve_data,
@@ -267,3 +270,74 @@ def test_value_drink() -> None:
             posture="standing",
             drink=2,
         )
+
+
+@pytest.mark.parametrize("model", ["7933-2004", "7933-2023"])
+def test_applicability_limit_is_on_tr_minus_tdb_not_tr(model: str) -> None:
+    """ISO 7933 Annex A, Table A.1 limits (tr - tdb) to (0, 60), not raw tr.
+
+    tr=10, tdb=40 gives tr - tdb = -30 (out of range) even though the raw tr
+    value of 10 would have passed the old, incorrect (0, 60) check on tr
+    alone. See #225.
+    """
+    result = phs(
+        tdb=40,
+        tr=10,
+        rh=50,
+        v=0.5,
+        met=2.0,
+        clo=0.5,
+        posture="standing",
+        model=model,
+        round_output=False,
+    )
+    assert math.isnan(result.t_cr)
+
+
+def test_applicability_limit_metabolic_rate_is_standard_specific() -> None:
+    """ISO 7933 Annex A, Table A.1: the metabolic rate range is 56-250 W/m2 in the 2023
+    standard but 100-450 W/m2 in the 2004 standard, not the 2004 range for both.
+
+    met=1.5 (~87.2 W/m2) falls inside the 2023 range and outside the 2004 one. See #225.
+    """
+    kwargs = dict(
+        tdb=30,
+        tr=40,
+        rh=50,
+        v=0.5,
+        met=1.5,
+        clo=0.5,
+        posture="standing",
+        round_output=False,
+    )
+    assert not math.isnan(phs(model="7933-2023", **kwargs).t_cr)
+    assert math.isnan(phs(model="7933-2004", **kwargs).t_cr)
+
+
+def test_2023_forces_skin_temperature_to_equilibrium_on_minute_one() -> None:
+    """ISO 7933:2023 Annex E forces t_sk to its equilibrium value on minute 1, removing
+    the exponential lag for that one step; this special case is not present in the 2004
+    Annex E reference code. See #217.
+
+    Starting from an artificial t_sk=20 far from equilibrium, after 1 minute the 2023
+    model should already be close to equilibrium (>30 degC) while the 2004 model, still
+    exponentially averaging, remains much closer to the artificial starting value.
+    """
+    kwargs = dict(
+        tdb=40,
+        tr=40,
+        rh=35,
+        v=0.3,
+        met=2.58,
+        clo=0.5,
+        posture="standing",
+        wme=0,
+        duration=1,
+        limit_inputs=False,
+        round_output=False,
+        t_sk=20.0,
+    )
+    result_2023 = phs(model="7933-2023", **kwargs)
+    result_2004 = phs(model="7933-2004", **kwargs)
+    assert result_2023.t_sk > 30
+    assert result_2004.t_sk < result_2023.t_sk


### PR DESCRIPTION
## Summary
- Pinned `tests/conftest.py`'s `validation-data-comfort-models` fixture URL to the `v1.0.0` tag instead of `main` (#373), so upstream fixture changes can't silently affect CI before the pin is deliberately reviewed and bumped.
- Addressed Copilot review feedback on the 4.4.1 `phs` fix (#374): pass `param_name` explicitly to `valid_range()` for the `(tr - tdb)` check, and added regression tests for the applicability-limit and minute-1 skin-temperature behavior.

## Test plan
- `pytest tests/` — 505 passed, 1 expected xfail
- `ruff check` / `ruff format --check` — clean
- Verified on TestPyPI as `v4.4.2rc1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)