### PR TITLE
fix(utci): use np.log instead of np.log1p for saturation vapour pressure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,14 @@ Unreleased
 * Addressed Copilot review feedback on the 4.4.1 ``phs`` fix: pass ``param_name``
   explicitly to ``valid_range()`` for the ``(tr - tdb)`` check, and added regression
   tests for the applicability-limit and minute-1 skin-temperature behavior.
+* Fixed the saturation vapour pressure calculation in ``utci``
+  (`#372 <https://github.com/pythermalcomfort/pythermalcomfort/issues/372>`_): the
+  Hardy/Wexler equation's ``ln(T)`` term used ``np.log1p`` (which computes
+  ``ln(1 + T)``) instead of ``np.log``, inflating the saturation vapour pressure by
+  ~1%. The resulting UTCI error is negligible in mild conditions (~0.03 °C at 25 °C,
+  50% RH) but grows to ~0.7 °C at 40 °C, 80% RH, where UTCI matters most for heat
+  stress assessment. Updated the affected hard-coded test expectations and added a
+  regression test cross-checking ``utci``'s vapour pressure against ``p_sat``.
 
 4.4.1 (2026-08-18)
 ------------------

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -100,7 +100,7 @@ def utci(
             (-1.8680009 * np.power(10.0, -13)),
         ]
         tk = t_db + 273.15  # air temp in K
-        es = 2.7150305 * np.log1p(tk)
+        es = 2.7150305 * np.log(tk)
         for count, i in enumerate(g):
             es = es + (i * np.power(tk, count - 2))
         es = np.exp(es) * 0.01  # convert Pa to hPa

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -69,7 +69,7 @@ def utci(
         print(result.stress_category)  # "no thermal stress"
 
         result = utci(tdb=[25, 40], tr=25, v=1.0, rh=50)
-        print(result.utci)  # [24.6, 40.6]
+        print(result.utci)  # [24.6, 40.4]
     """
     # Validate inputs using the UtciInputs class
     UTCIInputs(

--- a/tests/test_utci.py
+++ b/tests/test_utci.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 
 from pythermalcomfort.models import utci
 from pythermalcomfort.models.utci import _utci_optimized
+from pythermalcomfort.utilities import p_sat
 from tests.conftest import Urls, retrieve_reference_table, validate_result
 
 
@@ -34,7 +36,7 @@ def test_utci_ip_uses_si_thresholds_for_stress_category() -> None:
     """Test that IP stress categories use the underlying SI UTCI value."""
     result = utci(tdb=77, tr=77, v=3.28084, rh=50, units="IP")
 
-    assert result.utci == 76.4
+    assert result.utci == 76.3
     assert result.stress_category == "no thermal stress"
 
 
@@ -48,7 +50,7 @@ def test_utci_ip_vector_stress_category() -> None:
         units="IP",
     )
 
-    np.testing.assert_allclose(result.utci, [76.4, 110.7])
+    np.testing.assert_allclose(result.utci, [76.3, 110.5])
     np.testing.assert_array_equal(
         result.stress_category,
         ["no thermal stress", "very strong heat stress"],
@@ -57,8 +59,8 @@ def test_utci_ip_vector_stress_category() -> None:
 
 def test_utci_stress_category_uses_rounded_si_value_by_default() -> None:
     """Test that default SI category mapping preserves rounded-output behavior."""
-    rounded = utci(tdb=26.24, tr=26.24, v=1, rh=50)
-    unrounded = utci(tdb=26.24, tr=26.24, v=1, rh=50, round_output=False)
+    rounded = utci(tdb=26.27, tr=26.27, v=1, rh=50)
+    unrounded = utci(tdb=26.27, tr=26.27, v=1, rh=50, round_output=False)
 
     assert rounded.utci == 26.0
     assert rounded.stress_category == "no thermal stress"
@@ -69,8 +71,8 @@ def test_utci_stress_category_uses_rounded_si_value_by_default() -> None:
 def test_utci_ip_stress_category_uses_unrounded_si_value_when_not_rounding() -> None:
     """Test that unrounded IP output maps categories from unrounded SI values."""
     result = utci(
-        tdb=79.232,
-        tr=79.232,
+        tdb=79.286,
+        tr=79.286,
         v=3.28084,
         rh=50,
         units="IP",
@@ -96,6 +98,25 @@ def test_utci_ip_out_of_range_stress_category_is_nan() -> None:
         units="IP",
     )
 
-    np.testing.assert_allclose(vector_result.utci, [76.4, np.nan], equal_nan=True)
+    np.testing.assert_allclose(vector_result.utci, [76.3, np.nan], equal_nan=True)
     assert vector_result.stress_category[0] == "no thermal stress"
     assert np.isnan(vector_result.stress_category[1])
+
+
+def test_utci_saturation_vapour_pressure_matches_p_sat() -> None:
+    """Test that UTCI's vapour pressure matches the independent p_sat formulation.
+
+    Regression test for #372, where np.log1p was used instead of np.log in the
+    Hardy equation, inflating the saturation vapour pressure by ~1%. Saturation
+    vapour pressure grows exponentially with temperature, so a given relative
+    error only becomes detectable in hot, humid conditions: at 25 C / 50% RH it
+    shifts UTCI by ~0.03 C, but at 40 C / 80% RH it reaches ~0.7 C.
+    """
+    tdb = 40
+    tr = 40
+    v = 1
+    rh = 80
+    pa = p_sat(tdb) * (rh / 100) / 1000
+    expected = _utci_optimized(tdb, v, tr - tdb, pa)
+    actual = utci(tdb=tdb, tr=tr, v=v, rh=rh, round_output=False).utci
+    assert actual == pytest.approx(expected, abs=0.1)


### PR DESCRIPTION
Fixes #372

## Problem

`utci.py` computed saturation vapour pressure with `np.log1p(tk)` — `ln(1 + T)` where the Hardy/Wexler equation requires `ln(T)`. The formula builds `ln(es)` and exponentiates at the end, so this inflated `es` by ~1%.

Saturation vapour pressure vs. steam-table values (hPa):

| tdb | `np.log1p` | `np.log` | reference |
|-----|-----------|----------|-----------|
| 0 °C  | 6.173  | 6.112  | 6.112  |
| 25 °C | 31.989 | 31.699 | 31.69  |
| 40 °C | 74.495 | 73.853 | 73.85  |

`p_sat()` in `utilities.py`, an independent implementation already in this codebase, uses `np.log`.

## Impact

UTCI was overestimated by ~0.03 °C at 25 °C/50% RH, rising to ~0.7–0.9 °C at 40–45 °C with high humidity which are the conditions UTCI is most used for.

## Tests

`test_utci` had five hard-coded expectations that failed, all pinned to the buggy output:
- Three were incidental snapshots (76.4 → 76.3, 110.7 → 110.5) where the previously incorrect formula had been used to generate benchmark values.
- Two were boundary tests whose inputs were chosen to land just above the 26.0 °C category threshold. I re-derived those inputs (26.24 → 26.27 °C) so they still test the rounding behaviour they were written for.

Added `test_utci_saturation_vapour_pressure_matches_p_sat`, cross-checking
`utci`'s vapour pressure against `p_sat` at 40 °C/80% RH. The two agree to ~0.02 °C with the fix and differ by ~0.72 °C without it. It was also confirmed that it fails when `np.log1p` is restored.