### PR TITLE
docs: clarify pmv_ppd_iso model parameter

### DIFF
--- a/pythermalcomfort/models/pmv_ppd_iso.py
+++ b/pythermalcomfort/models/pmv_ppd_iso.py
@@ -66,10 +66,13 @@ def pmv_ppd_iso(
     wme : float or list of floats, optional
         External work, [met]. Defaults to 0.
     model : str, optional
-        Select the model you want to use to calculate the PMV. Supported values are
-        "7730-2005" and "7730-2025". The PMV/PPD formulae are unchanged between the two
-        editions, so both currently return identical results; "7730-2025" is kept as the
-        default since it is the current edition of the standard.
+        The ISO 7730 edition to reference. Supported values are "7730-2005"
+        and "7730-2025"; any other value raises a ``ValueError``. The two
+        editions currently use identical PMV/PPD equations and applicability
+        limits, so this parameter does not affect the numerical result. It is
+        retained to record the intended edition, reject unsupported edition
+        values, and allow future differentiation if the editions diverge.
+        Defaults to "7730-2025", the current edition of the standard.
     units : str, optional
         Select the SI (International System of Units) or the IP (Imperial Units) system.
         Supported values are 'SI' and 'IP'. Defaults to 'SI'.


### PR DESCRIPTION
Clarifies the `model` parameter in `pmv_ppd_iso` to explain that ISO 7730:2005 and ISO 7730:2025 currently use identical PMV/PPD equations and applicability limits, so the parameter does not affect the numerical result.

The parameter is retained to record the intended ISO edition, reject unsupported editions, and allow future differentiation if the editions diverge.

No behavior changes.

Closes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the supported standard editions for PMV/PPD calculations.
  - Documented the default edition and behaviour for unsupported values.
  - Confirmed that the currently supported editions produce identical numerical results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->